### PR TITLE
Fix the spawn placement for players teleporting in survival mode

### DIFF
--- a/src/main/java/net/darkhax/huntingdim/dimension/TeleporterHunting.java
+++ b/src/main/java/net/darkhax/huntingdim/dimension/TeleporterHunting.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockPortal;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.EnumFacing;
 import net.minecraft.util.math.BlockPos;
@@ -11,6 +12,7 @@ import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.MathHelper;
 import net.minecraft.world.Teleporter;
 import net.minecraft.world.WorldServer;
+import net.minecraftforge.fml.relauncher.ReflectionHelper;
 
 public class TeleporterHunting extends Teleporter {
 
@@ -29,6 +31,9 @@ public class TeleporterHunting extends Teleporter {
     @Override
     public void placeInPortal (Entity entity, float rotationYaw) {
 
+        if (entityIn instanceof EntityPlayerMP && !((EntityPlayerMP)entityIn).capabilities.isCreativeMode)
+				ReflectionHelper.setPrivateValue(EntityPlayerMP.class, (EntityPlayerMP)entityIn, true, "invulnerableDimensionChange", "field_184851_cj");
+        
         // If a portal doesn't exist, make a new one.
         if (!this.placeInExistingPortal(entity, rotationYaw)) {
 

--- a/src/main/java/net/darkhax/huntingdim/dimension/TeleporterHunting.java
+++ b/src/main/java/net/darkhax/huntingdim/dimension/TeleporterHunting.java
@@ -33,7 +33,7 @@ public class TeleporterHunting extends Teleporter {
 
         if (entityIn instanceof EntityPlayerMP && !((EntityPlayerMP)entityIn).capabilities.isCreativeMode)
 				ReflectionHelper.setPrivateValue(EntityPlayerMP.class, (EntityPlayerMP)entityIn, true, "invulnerableDimensionChange", "field_184851_cj");
-        
+
         // If a portal doesn't exist, make a new one.
         if (!this.placeInExistingPortal(entity, rotationYaw)) {
 


### PR DESCRIPTION
When not in creative, the `invulnerableDimensionChange` flag isn't properly set for players traveling through a portal, which results in them spawning below the destination portal. Setting said flag to `true` in `placeInPortal` rectifies that!