### PR TITLE
Make ambient potion effects not tick down faster

### DIFF
--- a/src/main/java/net/darkhax/huntingdim/handler/DimensionEffectHandler.java
+++ b/src/main/java/net/darkhax/huntingdim/handler/DimensionEffectHandler.java
@@ -127,8 +127,8 @@ public class DimensionEffectHandler {
 
             for (final PotionEffect effect : event.getEntityLiving().getActivePotionEffects()) {
 
-                // If the effect is positive
-                if (PotionUtils.isBeneficial(effect.getPotion())) {
+                // If the effect is positive and not ambient (e.g. Beacon)
+                if (PotionUtils.isBeneficial(effect.getPotion()) && !effect.getIsAmbient()) {
 
                     // Lower the duration by a second tick.
                     PotionUtils.deincrementDuration(effect);


### PR DESCRIPTION
Ambient effects such as from Beacons should probably not tick down faster as they will be reapplied anyway.

This was especially troublesome with Totemic's Enderman totem, which gives an ambient Night Vision effect. Usually the duration of that will always be above 10 seconds to prevent the screen from flickering, but in the Hunting Dimension, it is constantly dipping below 10 seconds.