### PR TITLE
fix weather updates not happening

### DIFF
--- a/src/main/java/net/darkhax/huntingdim/dimension/WorldProviderHunting.java
+++ b/src/main/java/net/darkhax/huntingdim/dimension/WorldProviderHunting.java
@@ -38,6 +38,7 @@ public class WorldProviderHunting extends WorldProvider {
 
         // Override generator settings
         WorldUtils.setWorldSettings(this, ConfigurationHandler.generatorPreset);
+        this.hasSkyLight = true;
     }
 
     @Override
@@ -86,5 +87,15 @@ public class WorldProviderHunting extends WorldProvider {
     public long getWorldTime () {
 
         return MIDNIGHT;
+    }
+    
+    @Override
+    public float getSunBrightness(float par1) {
+        return 0;
+    }
+
+    @Override
+    public float getSunBrightnessFactor(float par1) {
+        return 0;
     }
 }


### PR DESCRIPTION
Fixes #17

It appears weather cycle update is skipped when the provider doesn't have skylight set to true (which in your case is because you don't call `super.init()`). See `net.minecraft.world.World#updateWeatherBody`

Sun method overrides seem to maintain the 'always nighttime' environment, though I'm sure some double checking that nothing else derped would be advisable.